### PR TITLE
Automate seed data generation & Change used seed data to AR focus.

### DIFF
--- a/backend/oasst_backend/config.py
+++ b/backend/oasst_backend/config.py
@@ -200,7 +200,7 @@ class Settings(BaseSettings):
 
     DEBUG_USE_SEED_DATA: bool = False
     DEBUG_USE_SEED_DATA_PATH: Optional[FilePath] = (
-        Path(__file__).parent.parent / "test_data/realistic/realistic_seed_data.json"
+        Path(__file__).parent.parent / "test_data/AR_document_request_seed_data.json"
     )
     DEBUG_ALLOW_SELF_LABELING: bool = False  # allow users to label their own messages
     DEBUG_ALLOW_SELF_RANKING: bool = False  # allow users to rank their own messages

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ sqlmodel==0.0.8
 tqdm>=4.64.1
 uuid7==0.1.0
 uvicorn==0.20.0
+openai==1.16.2

--- a/backend/test_data/AR_document_request_seed_data.json
+++ b/backend/test_data/AR_document_request_seed_data.json
@@ -1,0 +1,107 @@
+[
+  {
+    "task_message_id": "akcwtmb4",
+    "user_message_id": "8ouhqnjq",
+    "parent_message_id": null,
+    "text": "Please submit a document outlining the impact of eco-friendly vegan fashion on reducing harm to animals in the fashion industry.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "4cfrzbu9",
+    "user_message_id": "udzo5116",
+    "parent_message_id": null,
+    "text": "Please submit a document exploring the impact of eco-feminism on the animal rights movement.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "vtczliv6",
+    "user_message_id": "umnlo5em",
+    "parent_message_id": null,
+    "text": "Please submit a document detailing the impact of palm oil production on wildlife and ecosystems in Southeast Asia, and the importance of choosing sustainable alternatives in support of animal rights.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "jlcbl88m",
+    "user_message_id": "r9xn0uj8",
+    "parent_message_id": null,
+    "text": "Please submit a document analyzing the ethical considerations of using artificial intelligence in wildlife conservation efforts.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "w1j11v2u",
+    "user_message_id": "ccwjtlns",
+    "parent_message_id": null,
+    "text": "Please submit a document on the impact of factory farming on indigenous communities and their traditional lands.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "hglsajhc",
+    "user_message_id": "7hp6n329",
+    "parent_message_id": null,
+    "text": "Please submit a document on the impact of climate change on endangered species and wildlife habitats.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "dg6uacws",
+    "user_message_id": "nwzs8s0q",
+    "parent_message_id": null,
+    "text": "Please submit a document analyzing the impact of unconventional farming practices, such as vertical farming, on animal welfare.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "7k7h4wey",
+    "user_message_id": "cpozkl3w",
+    "parent_message_id": null,
+    "text": "Please submit a document outlining the ethical considerations of using animals for entertainment purposes in zoos and aquariums around the world, including examples of successful advocacy campaigns that have led to improvements in animal welfare standards.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "nj6kx70x",
+    "user_message_id": "tn006j1n",
+    "parent_message_id": null,
+    "text": "Please submit a document exploring the depiction of animals in indigenous folklore and its impact on modern conceptualizations of animal rights.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "ptbtupxo",
+    "user_message_id": "pmp251yw",
+    "parent_message_id": null,
+    "text": "Please submit a document exploring the psychological impact of factory farming on farm animals.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "w91t3m0r",
+    "user_message_id": "7gnenktc",
+    "parent_message_id": null,
+    "text": "Please submit a document exploring the cultural significance of plant-based diets in ancient civilizations.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "37i3isdw",
+    "user_message_id": "eo01ay6l",
+    "parent_message_id": null,
+    "text": "\"Please submit a document detailing the impact of ecotourism on wildlife conservation efforts in developing countries.\"",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "qs91b40v",
+    "user_message_id": "564nmwbi",
+    "parent_message_id": null,
+    "text": "Please submit a document analyzing the correlation between social media platforms and the rise of plant-based diets among Gen Z and Millennial populations.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "2vpfmwm4",
+    "user_message_id": "zbl25trz",
+    "parent_message_id": null,
+    "text": "Please submit a document highlighting the impact of industrial animal agriculture on wildlife biodiversity in coastal regions.",
+    "role": "assistant"
+  },
+  {
+    "task_message_id": "tcmnoiga",
+    "user_message_id": "62p5v7bd",
+    "parent_message_id": null,
+    "text": "Please submit a document analyzing the impact of zoos on the mental and physical well-being of animal inhabitants, incorporating perspectives from animal experts and environmental advocates.",
+    "role": "assistant"
+  }
+]

--- a/backend/test_data/generate_seed_data.py
+++ b/backend/test_data/generate_seed_data.py
@@ -1,0 +1,132 @@
+import json
+import os
+import random
+import string
+
+from openai import OpenAI
+from tqdm import tqdm
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+class SeedData:
+    """
+    The SeedData class is used to manage and generate a seed data file. 
+    Set the DEBUG_USE_SEED_DATA_PATH variable in backend/oasst_backend/config.py to choose the seed data file to use.
+    """
+    def __init__(self):
+        self.data = [] # Stores all messages that need to be dumped in to the json seed data file
+        self.ids = set() # Stores all unique ids of the messages to avoid duplicate ids
+    
+    def add_message(self, message):
+        """
+        Adds a message to the to-be seed data file and tracks the ids to avoid duplicate ids.
+        """
+        self.data.append(message)
+        self.ids.add(message['task_message_id'])
+        self.ids.add(message['user_message_id'])
+        
+    
+
+    def generate_id(self, size=8, chars=string.ascii_lowercase + string.digits):
+        """
+        Generates a unique id for use as a task_message_id or user_message_id.
+        """
+        max_combinations = len(chars) ** size
+        if len(self.ids) >= max_combinations:
+            raise ValueError("All possible IDs are already in use")
+
+        while True:
+            res = ''.join(random.choice(chars) for _ in range(size))
+            if res not in self.ids:
+                return res
+            
+    def gen_message(self, parent_message_id, text, role):
+        """
+        Generates a message in the seed data message format.
+        """
+        return {
+            "task_message_id": self.generate_id(),
+            "user_message_id": self.generate_id(),
+            "parent_message_id": parent_message_id,
+            "text": text,
+            "role": role
+        }
+        
+    def dump(self, filename):
+        """
+        Converts the message list in to a json file.
+        """
+        with open(filename, 'w') as f:
+            json.dump(self.data, f)
+            
+    def animal_rights_doc_request(self):
+        """
+        Returns a request for a document relevant to animal rights using the OpenAI API.
+        Ex. "Please submit a document exploring the ethical considerations of using animals in circuses and the potential impact on their welfare and rights."
+        """
+        try:
+            # Adjusted for the OpenAI API chat completions endpoint
+            response = client.chat.completions.create(
+                model="gpt-3.5-turbo-0125",  # or the latest available model
+                messages=[
+                    {"role": "system", "content": ""},
+                    {"role": "user", "content": 
+                        "Generate a SINGLE request for a document relevant to animal rights. \
+                            Ex. 'Please submit a document about canadian laws pertaining to AG Gag Laws', \
+                                'Please submit a document about media's influence on food choices', \
+                            etc. I want a very diverse, creative set of document requests, all atleast somewhat relevant to animal rights and veganism.\
+                                Ask for unique things!"},
+                ],
+                temperature=1.3,
+                max_tokens=50,
+                top_p=1,
+                frequency_penalty=0,
+                presence_penalty=0
+            )
+            # Assuming the first completion is the one we want
+            output = response.choices[0].message.content
+            print(output)
+            return output
+        except Exception as e:
+            print("Error calling OpenAI API:", e)
+            return None
+    
+    # def animal_rights_doc_provide(self, topic):
+    #     """
+    #     Returns a fake URL to a subpage that seems to match up to the provided topic.
+    #     Ex. "https://***.***.***/***/[***]"
+    #     """
+    #     try:
+    #         # Adjusted for the OpenAI API chat completions endpoint
+    #         response = client.chat.completions.create(
+    #             model="gpt-3.5-turbo-0125",  # or the latest available model
+    #             messages=[
+    #                 {"role": "system", "content": ""},
+    #                 {"role": "user", "content": 
+    #                     f"Generate a fake URL to a subpage that seems to match up to this topic: {topic}\n Response MUST match: 'https://***.***.***/***/[***]'. asterisks do not indicate length."},
+    #             ],
+    #             temperature=1,
+    #             max_tokens=100,
+    #             top_p=1,
+    #             frequency_penalty=0,
+    #             presence_penalty=0
+    #         )
+    #         output = response.choices[0].message.content
+    #         print(output)
+    #         return output
+    #     except Exception as e:
+    #         print("Error calling OpenAI API:", e)
+    #         return None
+
+
+if __name__ == "__main__":
+    seed_data = SeedData()
+
+    # Append 15 messages to the seed data, each requesting a document related to animal rights.
+    for i in range(15):
+        doc_request = seed_data.gen_message(None, seed_data.animal_rights_doc_request(), "assistant")
+        seed_data.add_message(doc_request)
+
+    # If changing seed_data file, make sure to reconfigure DEBUG_USE_SEED_DATA_PATH variable in backend/oasst_backend/config.py
+    seed_data.dump("backend/test_data/AR_document_request_seed_data.json")
+


### PR DESCRIPTION
The `generate_seed_data.py` script is designed to create a seed data file. 

Presently, it's set up to generate a seed_data file containing 15 requests for assistant "Document Requests" all at least somewhat relevant to animal rights, utilizing the `gpt-3.5-turbo-0125` model for generation. This is for convenience in case we want to modify the seed data easily or experiment with different configurations.

Due to the change in `config.py`, the generated  `AR_document_request_seed_data.json` will be used.
Note: If your docker containers are already created, the only way I've explored so far in using the new seed data is this:

1. `Ctrl-C` on your database & frontend terminal processes if running.
2. Remove the loaded messages (and potentially other things) via `docker rm human-feedback-collection-db-1`
3. Rerun your database & frontend startup commands

 
The results are displayed in the `Reply with Document` panel accessible through the Dashboard @ [http://localhost:3000/dashboard](http://localhost:3000/dashboard)

![image](https://github.com/Open-Paws/Human-Feedback-Collection/assets/55062649/f345f35b-0db0-4d14-97b9-15c014995462)
![image](https://github.com/Open-Paws/Human-Feedback-Collection/assets/55062649/15fa6516-0c31-4f45-b2e3-705e17491c92)